### PR TITLE
Support schema-less URLs (eg //foo.com/foo/bar )

### DIFF
--- a/meta/views.py
+++ b/meta/views.py
@@ -53,6 +53,11 @@ class Meta(object):
             return None
         if url.startswith('http'):
             return url
+        if url.startswith('//'):
+            return '%s:%s' % (
+                self.get_protocol(),
+                url
+            )
         if url.startswith('/'):
             return '%s://%s%s' % (
                 self.get_protocol(),

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -90,6 +90,11 @@ class MetaObjectTestCase(unittest.TestCase):
         with self.assertRaises(ImproperlyConfigured):
             m.get_full_url('foo/bar')
 
+    def test_get_full_url_without_protocol_without_schema_will_raise(self):
+        m = Meta()
+        with self.assertRaises(ImproperlyConfigured):
+            m.get_full_url('//foo.com/foo/bar')
+
     def test_get_full_url_without_domain_will_raise(self):
         meta.settings.SITE_PROTOCOL = 'http'
         m = Meta()
@@ -102,6 +107,14 @@ class MetaObjectTestCase(unittest.TestCase):
         m = Meta()
         self.assertEqual(
             m.get_full_url('foo/bar'),
+            'https://foo.com/foo/bar'
+        )
+
+    def test_get_full_url_without_schema(self):
+        meta.settings.SITE_PROTOCOL = 'https'
+        m = Meta()
+        self.assertEqual(
+            m.get_full_url('//foo.com/foo/bar'),
             'https://foo.com/foo/bar'
         )
 


### PR DESCRIPTION
Resolves #13 