### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ OpenGraph_, Twitter, and Google Plus properties to their HTML responses.
 Installation
 ============
 
-See https://django-meta.readthedocs.org/en/latest/installation.html
+See https://django-meta.readthedocs.io/en/latest/installation.html
 
 Supported versions
 ==================
@@ -94,6 +94,6 @@ Please report all bugs to our Github `issue tracker`_.
 .. _issue tracker: https://github.com/nephila/django-meta/issues/
 .. _github: https://github.com/nephila/django-meta/
 .. _Iacopo Spalletti: https://github.com/yakky
-.. _documentation: http://django-meta.readthedocs.org/en/latest/
+.. _documentation: https://django-meta.readthedocs.io/en/latest/
 .. _Branko Vukelic: https://bitbucket.org/monwara
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,4 +19,4 @@ Installation
 * Optionally you can install and configure `sekizai`_
 
 
-.. _sekizai: https://django-sekizai.readthedocs.org/en/latest/#usage
+.. _sekizai: https://django-sekizai.readthedocs.io/en/latest/#usage


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.