### PR TITLE
Call super init in mixin so base views __init__ gets called

### DIFF
--- a/meta/views.py
+++ b/meta/views.py
@@ -150,6 +150,7 @@ class MetadataMixin(object):
         self.use_sites = settings.USE_SITES
         self.use_og = settings.USE_OG_PROPERTIES
         self.use_title_tag = settings.USE_TITLE_TAG
+        super(MetadataMixin, self).__init__(**kwargs)
 
     def get_meta_class(self):
         return self.meta_class

--- a/meta/views.py
+++ b/meta/views.py
@@ -150,7 +150,8 @@ class MetadataMixin(object):
         self.use_sites = settings.USE_SITES
         self.use_og = settings.USE_OG_PROPERTIES
         self.use_title_tag = settings.USE_TITLE_TAG
-        super(MetadataMixin, self).__init__(**kwargs)
+        if hasattr(super(MetadataMixin, self), '__init__'):
+            super(MetadataMixin, self).__init__(**kwargs)
 
     def get_meta_class(self):
         return self.meta_class


### PR DESCRIPTION
This fixes an issue in Django 1.10 where we were using the kwargs in the View.as_view(**kwargs) function and those attributes were not being set on the view as expected.