### PR TITLE
Wrap meta.html content in spaceless templatetag

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 ==================
 
 * Drop python 2.6/ Django<1.8
+* Wrap meta.html content in spaceless templatetag to suppress redundant newlines
 
 1.3.2 (2016-10-26)
 ==================

--- a/meta/templates/meta/meta.html
+++ b/meta/templates/meta/meta.html
@@ -1,4 +1,5 @@
 {% load meta %}
+{% spaceless %}
 {% autoescape off %}
 {% if meta %}
 	{% if meta.description %}{% meta 'description' meta.description %}{% endif %}
@@ -56,3 +57,4 @@
     {% endif %}
 {% endif %}
 {% endautoescape %}
+{% endspaceless %}


### PR DESCRIPTION
 to suppress redundant newlines

Fix #51 