### PR TITLE
Fix MetadataMixin.use_use_title_tag -> MetadataMixin.use_title_tag

### DIFF
--- a/meta/views.py
+++ b/meta/views.py
@@ -141,7 +141,7 @@ class MetadataMixin(object):
     locale = None
     use_sites = False
     use_og = False
-    use_use_title_tag = False
+    use_title_tag = False
     gplus_type = None
     gplus_author = None
     gplus_publisher = None


### PR DESCRIPTION
I suppose it's a bug. It escalated when I didn't call 'super' in my class using MetadataMixin ->

AttributeError: 'MyClass' object has no attribute 'use_title_tag'