### PR TITLE
Add support for og:image:secure_url

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ History
 * Added support for Python 3.7
 * Dropped support for Django < 1.11
 * Dropped  support for Python 3.4
+* Fixed support for og:image:secure_url
 * Fixed minor documentation error
 
 1.4.1 (2018-01-21)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -131,6 +131,12 @@ Use this setting to add a list of additional OpenGraph namespaces to be declared
 in the ``<head>`` tag.
 
 
+META_OG_SECURE_URL_ITEMS
+------------------------
+
+Use this setting to customize the list of additional OpenGraph properties for which the ``:secure_url`` suffix is added if the URL value is a ``https`` URL.
+
+
 Other settings
 --------------
 

--- a/meta/settings.py
+++ b/meta/settings.py
@@ -47,7 +47,7 @@ GPLUS_TYPES = (
     ('Review', _('Review')),
 )
 
-
+OG_SECURE_URL_ITEMS = getattr(django_settings, 'META_OG_SECURE_URL_ITEMS', ('image', 'audio', 'video'))
 DEFAULT_IMAGE = getattr(django_settings, 'META_DEFAULT_IMAGE', '')
 DEFAULT_TYPE = getattr(django_settings, 'META_SITE_TYPE', OBJECT_TYPES[0][0])
 FB_TYPE = getattr(django_settings, 'META_FB_TYPE', OBJECT_TYPES[0][0])

--- a/meta/templatetags/meta.py
+++ b/meta/templatetags/meta.py
@@ -7,6 +7,8 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.six import string_types
 
+from .. import settings
+
 register = template.Library()
 
 # Use sekizai if installed, otherwise define a templatetag stub
@@ -118,6 +120,8 @@ def og_prop(name, value):
     :param name: property name (without 'og:' namespace)
     :param value: property value
     """
+    if name in settings.OG_SECURE_URL_ITEMS and value.startswith('https'):
+        name = '%s:secure_url' % name
     return custom_meta('property', 'og:%s' % name, value)
 
 

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -157,6 +157,18 @@ class TestMeta(BaseTestCase):
         self.assertContains(response, '<meta name="twitter:image" content="http://example.com/path/to/image">')
         self.assertContains(response, '<link rel="publisher" href="https://plus.google.com/{0}"/>'.format('+FooPub'))
 
+    def test_templatetag_secure_image(self):
+        """
+        Test for issue #79
+        """
+        settings.SITE_PROTOCOL = 'http'
+        response = self.client.get('/mixin/title/')
+        self.assertContains(response, '<meta property="og:image" content="http://example.com/path/to/image">')
+        settings.SITE_PROTOCOL = 'https'
+        response = self.client.get('/mixin/title/')
+        self.assertContains(response, '<meta property="og:image:secure_url" content="https://example.com/path/to/image">')
+        settings.SITE_PROTOCOL = 'http'
+
     def test_templatetag_no_og(self):
         from meta import settings
         settings.USE_OG_PROPERTIES = False

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -17,6 +17,25 @@ class OgPropTestCase(TestCase):
             '<meta property="og:type" content="website">'
         )
 
+    def test_og_prop_secure_url(self):
+        for content in ('image', 'video', 'audio'):
+            self.assertEqual(
+                og_prop(content, 'https://some/{}'.format(content)),
+                '<meta property="og:{0}:secure_url" content="https://some/{0}">'.format(content),
+            )
+            self.assertEqual(
+                og_prop(content, 'http://some/{}'.format(content)),
+                '<meta property="og:{0}" content="http://some/{0}">'.format(content),
+            )
+        self.assertEqual(
+            og_prop('random_type', 'https://some/random_type'),
+            '<meta property="og:random_type" content="https://some/random_type">',
+        )
+        self.assertEqual(
+            og_prop('random_type', 'http://some/random_type'),
+            '<meta property="og:random_type" content="http://some/random_type">',
+        )
+
     def test_generic_prop_basically_works(self):
         self.assertEqual(
             generic_prop('og', 'type', 'website'),


### PR DESCRIPTION
By wrapping the logic inside the templatetag we can avoid any template change and 
make this change fully compatible with customized templates

Fix #79 