### PR TITLE
Alternative fix for #85

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ Contributors
 ------------
 
 * Adam Chainz
+* Basil Shubin
 * Branko Vukelic
 * Cansin Yildiz
 * Dmitry Fillo

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@
 History
 *******
 
+1.5.1 (2019-03-26)
+==================
+
+* Fixed error if the property referenced in _metadata returns False
+
 1.5.0 (2019-03-23)
 ==================
 

--- a/meta/models.py
+++ b/meta/models.py
@@ -78,18 +78,17 @@ class ModelMeta(object):
         :return: data
         """
         if value:
-            attr = getattr(self, value, False)
-            if attr is not False:
+            try:
+                attr = getattr(self, value)
                 if callable(attr):
                     try:
-                        data = attr(field)
+                        return attr(field)
                     except TypeError:
-                        data = attr()
+                        return attr()
                 else:
-                    data = attr
-            else:
-                data = value
-            return data
+                    return attr
+            except AttributeError:
+                return value
 
     def as_meta(self, request=None):
         """

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -71,6 +71,8 @@ class Post(ModelMeta, models.Model):
         'expiration_time': 'get_date',
         'url': 'get_full_url',
         'author': 'get_author_name',
+        'other_prop': 'get_other_prop',
+        'false_prop': 'get_false_prop',
     }
 
     class Meta:
@@ -116,3 +118,7 @@ class Post(ModelMeta, models.Model):
 
     def get_absolute_url(self):
         return reverse('post-detail', kwargs={'slug': self.slug})
+
+    @property
+    def get_false_prop(self):
+        return False

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -43,7 +43,7 @@ class TestMeta(BaseTestCase):
             'locale': 'dummy_locale',
             'image': 'http://example.com{}'.format(self.image_url),
             'object_type': 'Article',
-            'tag': False,
+            'tag': None,
             'keywords': ['post keyword1', 'post keyword 2'],
             'og_profile_id': '1111111111111',
             'twitter_description': 'post meta',
@@ -69,6 +69,8 @@ class TestMeta(BaseTestCase):
             'og_type': 'Article',
             'twitter_author': '@FooBar',
             'twitter_site': '@FooBlag',
+            'false_prop': False,
+            'other_prop': 'get_other_prop',
             'custom_namespace': ['foo', 'bar'],
         }
         settings.OG_NAMESPACES = ['foo', 'bar']
@@ -76,9 +78,9 @@ class TestMeta(BaseTestCase):
         settings.FB_APPID = 'appid'
         meta = self.post.as_meta()
         self.assertTrue(meta)
-        for key in ModelMeta._metadata_default.keys():
+        for key in expected.keys():
             value = expected[key]
-            if value is not False:
+            if value is not None:
                 self.assertEqual(value, getattr(meta, key))
             else:
                 self.assertFalse(hasattr(meta, key))


### PR DESCRIPTION
Alternative approach to #85 

We rely on `AttributeError` exception instead of `hasattr` for efficiency and cleanliness

Fix #85 
Fix #86