### PR TITLE
Add image size for facebook sharing

### DIFF
--- a/docs/views.rst
+++ b/docs/views.rst
@@ -30,6 +30,8 @@ the template context which contains any of the following attributes:
 + keywords
 + url
 + image
++ image_width
++ image_height
 + object_type
 + site_name
 + twitter_site
@@ -268,6 +270,16 @@ image
 
 This key should be the *full* URL of an image to be used with the ``og:image``,
 ``twitter:image``, ``itemprop=mage`` property.
+
+image_width
+-----------
+
+This key should be the width of image. It is used to render ``og:image:width`` value
+
+image_height
+------------
+
+This key should be the height of image. It is used to render ``og:image:height`` value
 
 object_type
 -----------

--- a/meta/models.py
+++ b/meta/models.py
@@ -29,6 +29,8 @@ class ModelMeta(object):
         'gplus_description': False,
         'keywords': False,
         'image': settings.DEFAULT_IMAGE,
+        'image_width': False,
+        'image_height': False,
         'object_type': settings.DEFAULT_TYPE,
         'og_type': settings.FB_TYPE,
         'og_app_id': settings.FB_APPID,

--- a/meta/templates/meta/meta.html
+++ b/meta/templates/meta/meta.html
@@ -16,6 +16,8 @@
         {% if meta.og_description %}{% og_prop 'description' meta.og_description %}
         {% elif meta.description %}{% og_prop 'description' meta.description %}{% endif %}
         {% if meta.image %}{% og_prop 'image' meta.image %}{% endif %}
+        {% if meta.image_width %}{% og_prop 'image:width' meta.image_width %}{% endif %}
+        {% if meta.image_height %}{% og_prop 'image:height' meta.image_height %}{% endif %}
         {% if meta.og_type %}{% og_prop 'type' meta.og_type %}
         {% elif meta.object_type %}{% og_prop 'type' meta.object_type %}{% endif %}
         {% if meta.site_name %}{% og_prop 'site_name' meta.site_name %}{% endif %}

--- a/meta/views.py
+++ b/meta/views.py
@@ -27,6 +27,8 @@ class Meta(object):
         self.keywords = kwargs.get('keywords')
         self.url = kwargs.get('url')
         self.image = kwargs.get('image')
+        self.image_width = kwargs.get('image_width')
+        self.image_height = kwargs.get('image_height')
         self.object_type = kwargs.get('object_type', settings.SITE_TYPE)
         self.site_name = kwargs.get('site_name', settings.SITE_NAME)
         self.twitter_site = kwargs.get('twitter_site')

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -19,9 +19,9 @@ class Post(ModelMeta, models.Model):
     Blog post
     """
     title = models.CharField(_('Title'), max_length=255)
-    og_title = models.CharField(_('Opengraph title', blank=True), max_length=255)
-    twitter_title = models.CharField(_('Twitter title', blank=True), max_length=255)
-    gplus_title = models.CharField(_('Gplus title', blank=True), max_length=255)
+    og_title = models.CharField(_('Opengraph title'), blank=True, max_length=255)
+    twitter_title = models.CharField(_('Twitter title'), blank=True, max_length=255)
+    gplus_title = models.CharField(_('Gplus title'), blank=True, max_length=255)
     slug = models.SlugField(_('slug'))
     abstract = models.TextField(_('Abstract'))
     meta_description = models.TextField(
@@ -55,6 +55,8 @@ class Post(ModelMeta, models.Model):
         'og_description': 'get_description',
         'keywords': 'get_keywords',
         'image': 'get_image_full_url',
+        'image_width': 'get_image_width',
+        'image_height': 'get_image_height',
         'object_type': 'Article',
         'og_type': 'Article',
         'og_profile_id': '1111111111111',
@@ -101,6 +103,14 @@ class Post(ModelMeta, models.Model):
     def get_image_full_url(self):
         if self.main_image:
             return self.build_absolute_uri(self.main_image.url)
+
+    def get_image_width(self):
+        if self.main_image:
+            return self.main_image.width
+
+    def get_image_height(self):
+        if self.main_image:
+            return self.main_image.height
 
     def get_full_url(self):
         return self.build_absolute_uri(self.get_absolute_url())

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -36,12 +36,16 @@ class TestMeta(BaseTestCase):
         self.post.main_image = self.create_django_image_object()
         self.post.save()
         self.image_url = self.post.main_image.url
+        self.image_width = self.post.main_image.width
+        self.image_height = self.post.main_image.height
 
     @override_settings(META_SITE_PROTOCOL='http')
     def test_as_meta(self):
         expected = {
             'locale': 'dummy_locale',
             'image': 'http://example.com{}'.format(self.image_url),
+            'image_width': self.image_width,
+            'image_height': self.image_height,
             'object_type': 'Article',
             'tag': None,
             'keywords': ['post keyword1', 'post keyword 2'],
@@ -99,6 +103,8 @@ class TestMeta(BaseTestCase):
         expected = {
             'locale': 'dummy_locale',
             'image': 'https://testserver{}'.format(self.image_url),
+            'image_width': self.image_width,
+            'image_height': self.image_height,
             'object_type': 'Article',
             'tag': False,
             'keywords': ['post keyword1', 'post keyword 2'],


### PR DESCRIPTION
According to Facebook documentation

https://developers.facebook.com/docs/sharing/best-practices/?locale=en_US#precaching

adding   og:image:width and og:image:height properties will help facebook crawler to figure out right image dimensions. It will render the shared image at the first post sharing.

Currently, the first person who shares the post doesn't see the image. The image becomes available after the second post.