### PR TITLE
Init djangocms-helper when loading cms_helper as module

### DIFF
--- a/cms_helper.py
+++ b/cms_helper.py
@@ -42,3 +42,7 @@ def setup():
 
 if __name__ == '__main__':
     run()
+
+
+if __name__ == 'cms_helper':
+    setup()


### PR DESCRIPTION
This is mostly useful when integrating external testing tools (e.g.: PyCharm integrated debugger)