### PR TITLE
Add Django 3.0 support

### DIFF
--- a/meta/templatetags/meta.py
+++ b/meta/templatetags/meta.py
@@ -5,7 +5,7 @@ from django import template
 from django.apps import apps
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-from django.utils.six import string_types
+from six import string_types
 
 from .. import settings
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,isort,py{37,36,35}-django{22,21,20}-{sekizai,nosekizai},py{37,36,35,27}-django{111}-{sekizai,nosekizai}
+envlist = pep8,isort,py{37,36,35}-django{30,22,21,20}-{sekizai,nosekizai},py{37,36,35,27}-django{111}-{sekizai,nosekizai}
 skip_missing_interpreters=True
 
 [testenv]
@@ -11,6 +11,7 @@ deps =
     django20: django~=2.0.0
     django21: django~=2.1.0
     django22: django~=2.2.0
+    django30: django~=3.0.0
     sekizai: django-sekizai
     -r{toxinidir}/requirements-test.txt
 


### PR DESCRIPTION
Fixes issue #96 regarding the use of deprecated internal Django APIs causing incompatibility with Django 3.0.

~~Seeing as Python 2 EOL is getting dangerously close I also dropped anything related to Python 2.~~ (see below comment)