### PR TITLE
Add explicit six dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install -U setuptools 'tox>=1.8' coveralls
+  - pip install -U setuptools 'tox>=1.8' 'coveralls>=1.10.0'
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PYVER=py36; fi"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,11 @@ Unreleased
 
 * Nothing yet
 
+1.6.1 (unreleased)
+==================
+
+* Added explicit dependency on six
+
 1.6.0 (2019-12-22)
 ==================
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-coverage<5.0
+coverage>=5
 coveralls
 mock>=1.0.1
 flake8>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     url='https://github.com/nephila/django-meta',
     license='BSD',
     install_requires=[
+        'six',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
As we removed django shims in #97 

See https://github.com/nephila/django-meta/commit/5d8238b8b93d395cacd6a3febb072a844898f9cb#commitcomment-36818229

Thanks @2tunnels  for reporting