### PR TITLE
Fix support for secure_url

### DIFF
--- a/meta/templatetags/meta.py
+++ b/meta/templatetags/meta.py
@@ -122,9 +122,10 @@ def og_prop(name, value):
     :param name: property name (without 'og:' namespace)
     :param value: property value
     """
+    content = [custom_meta('property', 'og:%s' % name, value)]
     if name in settings.OG_SECURE_URL_ITEMS and value.startswith('https'):
-        name = '%s:secure_url' % name
-    return custom_meta('property', 'og:%s' % name, value)
+        content.append(custom_meta('property', 'og:%s:secure_url' % name, value))
+    return '\n'.join(content)
 
 
 @register.simple_tag

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -189,6 +189,7 @@ class TestMeta(BaseTestCase):
         self.assertContains(response, '<meta property="og:image" content="http://example.com/path/to/image">')
         settings.SITE_PROTOCOL = 'https'
         response = self.client.get('/mixin/title/')
+        self.assertContains(response, '<meta property="og:image" content="https://example.com/path/to/image">')
         self.assertContains(response, '<meta property="og:image:secure_url" content="https://example.com/path/to/image">')
         settings.SITE_PROTOCOL = 'http'
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -25,6 +25,7 @@ class OgPropTestCase(TestCase):
         for content in ('image', 'video', 'audio'):
             self.assertEqual(
                 og_prop(content, 'https://some/{}'.format(content)),
+                '<meta property="og:{0}" content="https://some/{0}">\n'
                 '<meta property="og:{0}:secure_url" content="https://some/{0}">'.format(content),
             )
             self.assertEqual(


### PR DESCRIPTION
Render both `og:image` and `og:image:secure_url` if https is enabled

Fix #79 
Fix #107 