### PR TITLE
Add support for image object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,10 +88,6 @@ Please report all bugs to our Github `issue tracker`_.
     :target: https://coveralls.io/r/nephila/django-meta?branch=master
     :alt: Test coverage
 
-.. |License| image:: https://img.shields.io/github/license/nephila/django-meta.svg?style=flat-square
-   :target: https://pypi.python.org/pypi/django-meta/
-    :alt: License
-
 .. |CodeClimate| image:: https://codeclimate.com/github/nephila/django-meta/badges/gpa.svg?style=flat-square
    :target: https://codeclimate.com/github/nephila/django-meta
    :alt: Code Climate

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -170,7 +170,6 @@ it will be rendered as::
 
 .. note: as of version 2.0, this is the preferred way to set image information.
 
-.. _view mixin:
 
 Meta.image
 ~~~~~~~~~~~~~
@@ -321,11 +320,29 @@ url
 This key should be the *full* URL of the page. It is used to render the
 ``og:url``, ``twitter:url``, ``itemprop=url`` property.
 
+image_object
+~~~~~~~~~~~~~
+
+This key must be set to a dictionary containing at least the ``url`` key, additional
+keys will be rendered if supported by each protocol. Currently only OpenGraph supports
+additional image properties.
+
+Example::
+
+    media = {
+        'url': 'http://meta.example.com/image.gif',
+        'secure_url': 'https://meta.example.com/custom.gif',
+        'type': 'some/mime',
+        'width': 100,
+        'height': 100,
+        'alt': 'a media',
+    }
+
 image
 ~~~~~~~~~~~~~
 
 This key should be the *full* URL of an image to be used with the ``og:image``,
-``twitter:image``, ``itemprop=mage`` property.
+``twitter:image``, ``itemprop=image`` property.
 
 image_width
 ~~~~~~~~~~~~~

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -30,6 +30,7 @@ the template context which contains any of the following attributes:
 + keywords
 + url
 + image
++ image_object
 + image_width
 + image_height
 + object_type
@@ -91,6 +92,7 @@ and will modify values you set. These properties are:
 + keywords
 + url
 + image
++ image_object
 
 For brevity, we will only discuss those here.
 
@@ -128,12 +130,57 @@ to calculate the domain, you can either set the :ref:`META_USE_SITES` setting to
 Note that using the sites app will trigger database queries and/or cache hits,
 and it is therefore disabled by default.
 
+Meta.image_object
+~~~~~~~~~~~~~~~~~
+
+The ``image_object`` property is the most complete way to provide image meta.
+
+To use this property, you must pass a dictionary with at least the ``url`` attribute.
+
+All others keys will be rendered alongside the ``url``, if the specific protocol
+provides it.
+
+Currently only OpenGraph support more than the image url, and you might add:
+
+* ``width``: image width
+* ``height``: image height
+* ``alt``: alternate image description
+* ``secure_url``: https URL for the image, if different than the ``url`` key
+* ``type``: image mime type
+
+example::
+
+    media = {
+        'url': 'http://meta.example.com/image.gif',
+        'secure_url': 'https://meta.example.com/custom.gif',
+        'type': 'some/mime',
+        'width': 100,
+        'height': 100,
+        'alt': 'a media',
+    }
+
+it will be rendered as::
+
+    <meta property="og:image:alt" content="a media">
+    <meta property="og:image:height" content="100">
+    <meta property="og:image:secure_url" content="https://meta.example.com/image.gif">
+    <meta property="og:image:type" content="some/mime">
+    <meta property="og:image:url" content="http://meta.example.com/image.gif">
+    <meta property="og:image:width" content="100">
+
+.. note: as of version 2.0, this is the preferred way to set image information.
+
+.. _view mixin:
+
 Meta.image
 ~~~~~~~~~~~~~
 
 The ``image`` property behaves the same way as ``url`` property with one
 notable difference. This property treats absolute and relative paths
 differently. It will place relative paths under the :ref:`META_IMAGE_URL`.
+
+if ``image_object`` is provided, it takes precedence over this property, for all
+the protocols, even if they only support the image URL.
 
 .. _view mixin:
 

--- a/meta/models.py
+++ b/meta/models.py
@@ -29,6 +29,7 @@ class ModelMeta(object):
         'schemaorg_description': False,
         'keywords': False,
         'image': settings.DEFAULT_IMAGE,
+        'image_object': None,
         'image_width': False,
         'image_height': False,
         'object_type': settings.DEFAULT_TYPE,

--- a/meta/templates/meta/meta.html
+++ b/meta/templates/meta/meta.html
@@ -15,9 +15,13 @@
         {% if meta.url %}{% og_prop 'url' meta.url %}{% endif %}
         {% if meta.og_description %}{% og_prop 'description' meta.og_description %}
         {% elif meta.description %}{% og_prop 'description' meta.description %}{% endif %}
-        {% if meta.image %}{% og_prop 'image' meta.image %}{% endif %}
-        {% if meta.image_width %}{% og_prop 'image:width' meta.image_width %}{% endif %}
-        {% if meta.image_height %}{% og_prop 'image:height' meta.image_height %}{% endif %}
+        {% if meta.image_object %}
+          {% og_prop 'image' meta.image_object %}
+        {% else %}
+          {% if meta.image %}{% og_prop 'image' meta.image %}{% endif %}
+          {% if meta.image_width %}{% og_prop 'image:width' meta.image_width %}{% endif %}
+          {% if meta.image_height %}{% og_prop 'image:height' meta.image_height %}{% endif %}
+        {% endif %}
         {% if meta.og_type %}{% og_prop 'type' meta.og_type %}
         {% elif meta.object_type %}{% og_prop 'type' meta.object_type %}{% endif %}
         {% if meta.site_name %}{% og_prop 'site_name' meta.site_name %}{% endif %}

--- a/meta/templatetags/meta.py
+++ b/meta/templatetags/meta.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import warnings
+from collections import OrderedDict
 
 from django import template
 from django.apps import apps
@@ -122,9 +123,19 @@ def og_prop(name, value):
     :param name: property name (without 'og:' namespace)
     :param value: property value
     """
-    content = [custom_meta('property', 'og:%s' % name, value)]
-    if name in settings.OG_SECURE_URL_ITEMS and value.startswith('https'):
-        content.append(custom_meta('property', 'og:%s:secure_url' % name, value))
+    if not isinstance(value, dict) and name in settings.OG_SECURE_URL_ITEMS and value.startswith('https'):
+        data = {
+            name: value,
+            '%s:secure_url' % name: value
+        }
+    elif not isinstance(value, dict):
+        data = {
+            name: value,
+        }
+    else:
+        data = {'%s:%s' % (name, key): val for key, val in value.items()}
+    data = OrderedDict(sorted(data.items()))
+    content = [custom_meta('property', 'og:%s' % key, val) for key, val in data.items()]
     return '\n'.join(content)
 
 

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -54,6 +54,7 @@ class Post(ModelMeta, models.Model):
         'description': 'get_description',
         'og_description': 'get_description',
         'keywords': 'get_keywords',
+        'image_object': 'get_image_object',
         'image': 'get_image_full_url',
         'image_width': 'get_image_width',
         'image_height': 'get_image_height',
@@ -101,6 +102,15 @@ class Post(ModelMeta, models.Model):
         if not description:
             description = self.abstract
         return description.strip()
+
+    def get_image_object(self):
+        if self.main_image:
+            return {
+                'url': self.build_absolute_uri(self.main_image.url),
+                'width': self.main_image.width,
+                'height': self.main_image.height,
+                'alt': self.title,
+            }
 
     def get_image_full_url(self):
         if self.main_image:

--- a/tests/example_app/urls.py
+++ b/tests/example_app/urls.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 
-from .views import PostDetailView, PostListView, PostMixinDetailView
+from .views import PostDetailView, PostListView, PostMixinDetailView, PostMixinImageObjectDetailView
 
 try:
     from django.views.i18n import JavaScriptCatalog
@@ -21,6 +21,7 @@ urlpatterns = [
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
     url(r'^jsi18n/(?P<packages>\S+?)/$', javascript_catalog),  # NOQA
     url(r'^mixin/(?P<slug>\w[-\w]*)/$', PostMixinDetailView.as_view(), name='post-detail-mixinx'),
+    url(r'^mixin_image/(?P<slug>\w[-\w]*)/$', PostMixinImageObjectDetailView.as_view(), name='post-detail-image-mixinx'),
     url(r'^(?P<slug>\w[-\w]*)/$', PostDetailView.as_view(), name='post-detail'),
     url(r'^$', PostListView.as_view(), name='post-list'),
 ]

--- a/tests/example_app/views.py
+++ b/tests/example_app/views.py
@@ -33,6 +33,12 @@ class PostMixinDetailView(MetadataMixin, DetailView):
         return self.object.image_url
 
 
+class PostMixinImageObjectDetailView(PostMixinDetailView):
+
+    def get_meta_image_object(self, context=None):
+        return self.object.get_image_object()
+
+
 class PostListView(MetadataMixin, ListView):
     model = Post
     title = 'Some page'

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -41,6 +41,27 @@ class OgPropTestCase(TestCase):
             '<meta property="og:random_type" content="http://some/random_type">',
         )
 
+    def test_og_full_media_data(self):
+        media = {
+            'url': 'https://some/media.url',
+            'secure_url': 'https://some/media.url',
+            'type': 'some/mime',
+            'width': 100,
+            'height': 100,
+            'alt': 'a media',
+        }
+        for content in ('image', 'video', 'audio'):
+            self.assertEqual(
+                og_prop(content, media),
+                '<meta property="og:{0}:alt" content="a media">\n'
+                '<meta property="og:{0}:height" content="100">\n'
+                '<meta property="og:{0}:secure_url" content="https://some/media.url">\n'
+                '<meta property="og:{0}:type" content="some/mime">\n'
+                '<meta property="og:{0}:url" content="https://some/media.url">\n'
+                '<meta property="og:{0}:width" content="100">'
+                ''.format(content),
+            )
+
     def test_generic_prop_basically_works(self):
         self.assertEqual(
             generic_prop('og', 'type', 'website'),


### PR DESCRIPTION
Add support for ``image_object`` property, to allow managing all the og:image properties (url, alt, height, width) with a single property

Original ``image`` property is kept for compatibility purposes, but if ``image_object`` is set, its value it's ignored and the ``image_object`` url is used instead