### PR TITLE
Updated import to support Django 4.0

### DIFF
--- a/meta/settings.py
+++ b/meta/settings.py
@@ -1,5 +1,5 @@
 from django.conf import settings as django_settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 SITE_PROTOCOL = getattr(django_settings, "META_SITE_PROTOCOL", None)
 SITE_DOMAIN = getattr(django_settings, "META_SITE_DOMAIN", None)


### PR DESCRIPTION
ugettext_lazy function was deprecated and no longer supported in Django 4.0 we should use gettext_lazy instead

See reference:
https://code.djangoproject.com/ticket/30165

# Description

Describe:

* Content of the pull request
* Feature added / Problem fixed

## References

Provide any github issue fixed (as in ``Fix #XYZ``)

# Checklist

* [x] I have read the [contribution guide](https://django-meta.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
