### PR TITLE
Fix META_USE_SITE setting access in build_absolute_uri()

### DIFF
--- a/changes/133.bugfix
+++ b/changes/133.bugfix
@@ -1,0 +1,1 @@
+Get correct setting META_USE_SITES in build_absolute_uri model method

--- a/meta/models.py
+++ b/meta/models.py
@@ -6,9 +6,10 @@ from django.conf import settings as dj_settings
 from . import settings
 from .utils import get_request, set_request
 
-NEED_REQUEST_OBJECT_ERR_MSG = """
-Meta models needs request objects when initializing if sites framework is not used.
-""".strip()
+NEED_REQUEST_OBJECT_ERR_MSG = (
+    "Meta models needs request objects when initializing if sites framework "
+    "is not used. See META_USE_SITES setting."
+).strip()
 
 
 class ModelMeta:
@@ -186,7 +187,7 @@ class ModelMeta:
         if request:
             return request.build_absolute_uri(url)
 
-        if not dj_settings.META_USE_SITES:
+        if not settings.USE_SITES:
             raise RuntimeError(NEED_REQUEST_OBJECT_ERR_MSG)
 
         from django.contrib.sites.models import Site


### PR DESCRIPTION
# Description

Use the correct setting name (`USE_SITES` instead of `META_USE_SITES`) from the correct setting module (`meta.settings` instead of `django.conf.settings`)

## References

Fix #133 

# Checklist

* [x] I have read the [contribution guide](https://django-meta.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
