### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -165,7 +165,7 @@ Release a version
 #. Publish the release from the tags page
 #. If pipeline succeeds, push ``master``
 #. Merge ``master`` back on ``develop``
-#. Bump developement version via task: ``inv tag-dev -l (major|minor|patch)``
+#. Bump development version via task: ``inv tag-dev -l (major|minor|patch)``
 #. Push ``develop``
 
 .. _towncrier: https://pypi.org/project/towncrier/#news-fragments

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ Installation
     )
 
 * Add the :ref:`required namespace tags<rendering>` to your base template
-  for compliancy with metadata protocols.
+  for compliance with metadata protocols.
 
 * Optionally you can install and configure `sekizai`_
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -48,7 +48,7 @@ use in the template;
 ``ModelMeta.get_request()``: returns the ``request`` object, if given as argument to ``as_meta``;
 
 ``ModelMeta.get_author()``: returns the author object for the current instance. Default
-implementation does not return a valid object, this **must** be overidden in the application
+implementation does not return a valid object, this **must** be overridden in the application
 according to what is an author in the application domain;
 
 ``ModelMeta.build_absolute_uri(url)``: create an absolute URL (i.e.: complete with protocol and

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -110,7 +110,7 @@ instead.
 Meta.url
 ~~~~~~~~~~~~~
 
-Setting the url behaves differently depending on whether you are passsing a
+Setting the url behaves differently depending on whether you are passing a
 path or a full URL. If your URL starts with ``'http'``, it will be used
 verbatim (not that the actual validity of the url is not checked so
 ``'httpfoo'`` will be considered a valid URL). If you use an absolute or
@@ -213,7 +213,7 @@ meta tags (see :ref:`rendering`).
 Each of the properties on the mixin can be calculated dynamically by using the
 ``MetadataMixin.get_meta_PROPERTYNAME`` methods, where ``PROPERTYNAME`` is the
 name of the property you wish the calculate at runtime. Each method will
-receive a ``context`` keyword argument containig the request context.
+receive a ``context`` keyword argument containing the request context.
 
 For example, to calculate the description dynamically, you may use the mixin
 like so::
@@ -299,7 +299,7 @@ The service-specific variants are also supported:
 * ``twitter_title``
 * ``schema_title``
 
-If set on the ``Meta`` object, they will be used insteaf of the generic title
+If set on the ``Meta`` object, they will be used instead of the generic title
 which will be used as a fallback.
 
 description


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.rst
- docs/installation.rst
- docs/models.rst
- docs/views.rst

Fixes:
- Should read `passing` rather than `passsing`.
- Should read `overridden` rather than `overidden`.
- Should read `instead` rather than `insteaf`.
- Should read `development` rather than `developement`.
- Should read `containing` rather than `containig`.
- Should read `compliance` rather than `compliancy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md