### PR TITLE
Fix request set order in Meta.__init__

### DIFF
--- a/changes/155.bugfix
+++ b/changes/155.bugfix
@@ -1,0 +1,1 @@
+Fix request set order in Meta.__init__

--- a/meta/views.py
+++ b/meta/views.py
@@ -17,6 +17,7 @@ class Meta:
     request = None
 
     def __init__(self, **kwargs):
+        self.request = kwargs.get("request", None)
         self.use_sites = kwargs.get("use_sites", settings.USE_SITES)
         self.title = kwargs.get("title")
         self.og_title = kwargs.get("og_title")
@@ -48,7 +49,6 @@ class Meta:
         self.schemaorg_type = kwargs.get("schemaorg_type", settings.SCHEMAORG_TYPE)
         self.fb_pages = kwargs.get("fb_pages", settings.FB_PAGES)
         self.og_app_id = kwargs.get("og_app_id", settings.FB_APPID)
-        self.request = kwargs.get("request", None)
 
     def get_domain(self):
         if self.use_sites:

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,5 +1,6 @@
 from copy import copy
 
+from django.conf import settings as django_settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, TestCase, override_settings
@@ -72,6 +73,22 @@ class MetaObjectTestCase(TestCase):
         m = Meta(keywords=["foo", "bar"])
         self.assertEqual(m.keywords[0], "foo")
         self.assertEqual(m.keywords[1], "bar")
+
+    def test_set_image_request(self):
+        settings.USE_SITES = True
+        settings.SITE_PROTOCOL = "http"
+        django_settings.SITE_ID = None
+        factory = RequestFactory()
+        request = factory.get("/")
+        Site.objects.create(domain=request.get_host())
+        m = Meta(
+            request=request,
+            title="A page title",
+            image="/static/image.png",
+        )
+        self.assertEqual(m.image, "http://testserver/static/image.png'")
+        settings.USE_SITES = False
+        django_settings.SITE_ID = 1
 
     def test_set_keywords_with_include(self):
         settings.INCLUDE_KEYWORDS = ["baz"]

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -86,7 +86,7 @@ class MetaObjectTestCase(TestCase):
             title="A page title",
             image="/static/image.png",
         )
-        self.assertEqual(m.image, "http://testserver/static/image.png'")
+        self.assertEqual(m.image, "http://testserver/static/image.png")
         settings.USE_SITES = False
         django_settings.SITE_ID = 1
 


### PR DESCRIPTION
# Description

Move setting Meta.request at the start of __init__ method, to be able to use request object when setting other attributes

## References

Fix #155 

# Checklist

* [x] I have read the [contribution guide](https://django-meta.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
