### PR TITLE
Fix schemaorg_description not being in Meta class

### DIFF
--- a/changes/127.bugfix
+++ b/changes/127.bugfix
@@ -1,0 +1,1 @@
+Fix schemaorg_description not being in Meta class

--- a/meta/views.py
+++ b/meta/views.py
@@ -23,6 +23,7 @@ class Meta:
         self.og_title = kwargs.get("og_title")
         self.twitter_title = kwargs.get("twitter_title")
         self.schemaorg_title = kwargs.get("schemaorg_title")
+        self.schemaorg_description = kwargs.get("schemaorg_description")
         self.description = kwargs.get("description")
         self.extra_props = kwargs.get("extra_props")
         self.extra_custom_props = kwargs.get("extra_custom_props")
@@ -152,6 +153,7 @@ class MetadataMixin:
     og_title = None
     twitter_title = None
     schemaorg_title = None
+    schemaorg_description = None
     description = None
     extra_props = None
     extra_custom_props = None
@@ -198,6 +200,9 @@ class MetadataMixin:
 
     def get_meta_schemaorg_title(self, context=None):
         return self.schemaorg_title
+
+    def get_meta_schemaorg_description(self, context=None):
+        return self.schemaorg_description
 
     def get_meta_description(self, context=None):
         return self.description
@@ -274,6 +279,7 @@ class MetadataMixin:
             og_title=self.get_meta_og_title(context=context),
             twitter_title=self.get_meta_twitter_title(context=context),
             schemaorg_title=self.get_meta_schemaorg_title(context=context),
+            schemaorg_description=self.get_meta_schemaorg_description(context=context),
             description=self.get_meta_description(context=context),
             extra_props=self.get_meta_extra_props(context=context),
             extra_custom_props=self.get_meta_extra_custom_props(context=context),

--- a/tests/example_app/migrations/0001_initial.py
+++ b/tests/example_app/migrations/0001_initial.py
@@ -24,6 +24,10 @@ class Migration(migrations.Migration):
                 ("og_title", models.CharField(max_length=255, verbose_name="Opengraph title", blank=True)),
                 ("twitter_title", models.CharField(max_length=255, verbose_name="Twitter title", blank=True)),
                 ("schemaorg_title", models.CharField(max_length=255, verbose_name="Schema.org title", blank=True)),
+                (
+                    "schemaorg_description",
+                    models.CharField(max_length=255, verbose_name="Schema.org description", blank=True),
+                ),
                 ("slug", models.SlugField(verbose_name="slug")),
                 ("abstract", models.TextField(verbose_name="Abstract")),
                 ("meta_description", models.TextField(blank=True, default="", verbose_name="Post meta description")),

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -20,6 +20,7 @@ class Post(ModelMeta, models.Model):
     og_title = models.CharField(_("Opengraph title"), blank=True, max_length=255)
     twitter_title = models.CharField(_("Twitter title"), blank=True, max_length=255)
     schemaorg_title = models.CharField(_("Schema.org title"), blank=True, max_length=255)
+    schemaorg_description = models.CharField(_("Schema.org description"), blank=True, max_length=255)
     slug = models.SlugField(_("slug"))
     abstract = models.TextField(_("Abstract"))
     meta_description = models.TextField(verbose_name=_("Post meta description"), blank=True, default="")
@@ -41,6 +42,7 @@ class Post(ModelMeta, models.Model):
         "og_title": "og_title",
         "twitter_title": "twitter title",
         "schemaorg_title": "schemaorg title",
+        "schemaorg_description": "schemaorg description",
         "description": "get_description",
         "og_description": "get_description",
         "keywords": "get_keywords",

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -45,6 +45,7 @@ class MetaObjectTestCase(TestCase):
         self.assertEqual(m.title, None)
         self.assertEqual(m.og_title, None)
         self.assertEqual(m.schemaorg_title, None)
+        self.assertEqual(m.schemaorg_description, None)
         self.assertEqual(m.twitter_title, None)
         self.assertEqual(m.description, None)
         self.assertEqual(m.extra_props, None)

--- a/tests/test_metadata_mixin.py
+++ b/tests/test_metadata_mixin.py
@@ -40,6 +40,13 @@ class MetadataMixinTestCase(TestCase):
         m.schemaorg_title = "Foo"
         self.assertEqual(m.get_meta_schemaorg_title(), "Foo")
 
+    def test_get_meta_schemaorg_description(self):
+        m = MetadataMixin()
+        self.assertEqual(m.get_meta_schemaorg_description(), None)
+
+        m.schemaorg_description = "Foo"
+        self.assertEqual(m.get_meta_schemaorg_description(), "Foo")
+
     def test_get_meta_description(self):
         m = MetadataMixin()
         self.assertEqual(m.get_meta_description(), None)

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -23,6 +23,7 @@ class TestMeta(BaseTestCase):
             og_title="og title",
             twitter_title="twitter title",
             schemaorg_title="schemaorg title",
+            schemaorg_description="schemaorg description",
             slug="title",
             abstract="post abstract",
             meta_description="post meta",
@@ -55,7 +56,7 @@ class TestMeta(BaseTestCase):
             "og_title": "og title",
             "twitter_title": "twitter title",
             "schemaorg_title": "schemaorg title",
-            "schemaorg_description": "post meta",
+            "schemaorg_description": "schemaorg description",
             "expiration_time": self.post.date_published_end,
             "og_description": "post meta",
             "description": "post meta",
@@ -124,7 +125,7 @@ class TestMeta(BaseTestCase):
             "og_title": "og title",
             "twitter_title": "twitter title",
             "schemaorg_title": "schemaorg title",
-            "schemaorg_description": "post meta",
+            "schemaorg_description": "schemaorg description",
             "expiration_time": self.post.date_published_end,
             "og_description": "post meta",
             "description": "post meta",
@@ -181,7 +182,9 @@ class TestMeta(BaseTestCase):
         self.assertContains(
             response, '<meta name="twitter:image" content="http://example.com{}">'.format(self.image_url)
         )
-        self.assertContains(response, '<meta itemprop="description" content="{}">'.format(self.post.meta_description))
+        self.assertContains(
+            response, '<meta itemprop="description" content="{}">'.format(self.post.schemaorg_description)
+        )
         self.assertContains(
             response, '<meta name="twitter:description" content="{}">'.format(self.post.meta_description)
         )
@@ -269,7 +272,9 @@ class TestMeta(BaseTestCase):
         settings.USE_OG_PROPERTIES = False
         response = self.client.get("/title/")
         self.assertFalse(response.rendered_content.find("og:description") > -1)
-        self.assertContains(response, '<meta itemprop="description" content="{}">'.format(self.post.meta_description))
+        self.assertContains(
+            response, '<meta itemprop="description" content="{}">'.format(self.post.schemaorg_description)
+        )
         self.assertContains(
             response, '<meta name="twitter:description" content="{}">'.format(self.post.meta_description)
         )


### PR DESCRIPTION
# Description

Fix schemaorg_description not being in Meta class

## References

Fix #127 

# Checklist

* [x] I have read the [contribution guide](https://django-meta.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
