### PR TITLE
Add support for Django 5.2 and python 3.12 and 3.13, drop support for Django 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11.x, 3.10.x, 3.9]
-        django: [42, 32]
+        python-version: [3.13.x, 3.12.x, 3.11.x, 3.10.x, 3.9]
+        django: [52, 42]
         sekizai: [sekizai,nosekizai]
+        exclude:
+        - django: 52
+          python-version: 3.9
+        - django: 42
+          python-version: 3.13.x
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -28,14 +28,14 @@ Supported versions
 Django
 ******
 
-3.2 to 4.2 (newer versions might work but are not tested yet)
+4.2 to 5.2 (newer versions might work but are not tested yet)
 
 
 ******
 Python
 ******
 
-Python 3.9 to 3.11
+Python 3.9 to 3.13
 
 *******************
 Supported Meta Tags

--- a/changes/216.feature
+++ b/changes/216.feature
@@ -1,0 +1,1 @@
+Add support for Django 5.2 and python 3.12 and 3.13, remove support for Django 3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,8 @@ license_file = LICENSE
 classifiers =
 	Development Status :: 5 - Production/Stable
 	Framework :: Django
-	Framework :: Django :: 3.2
-	Framework :: Django :: 4.0
-	Framework :: Django :: 4.1
 	Framework :: Django :: 4.2
+    Framework :: Django :: 5.2
 	Environment :: Web Environment
 	Intended Audience :: Developers
 	License :: OSI Approved :: BSD License
@@ -27,13 +25,15 @@ classifiers =
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 include_package_data = True
 setup_requires =
 	setuptools
 packages = meta
-python_requires = >=3.7
+python_requires = >=3.9
 test_suite = cms_helper.run
 zip_safe = False
 
@@ -43,7 +43,7 @@ meta = *.html *.png *.gif *js *jpg *jpeg *svg *py *mo *po
 
 [options.extras_require]
 docs =
-	django<5.0
+	django<6.0
 	sphinx-rtd-theme
 
 [sdist]

--- a/tox.ini
+++ b/tox.ini
@@ -8,14 +8,15 @@ envlist =
     ruff
     pypi-description
     towncrier
-    py{311,310,39}-django{42,32}-{sekizai,nosekizai}
+    py{313,312,311,310}-django52-{sekizai,nosekizai}
+    py{312,311,310}-django42-{sekizai,nosekizai}
 minversion = 3.23
 
 [testenv]
 commands = {env:COMMAND:python} cms_helper.py meta test {posargs}
 deps =
-    django32: django~=3.2.0
     django42: django~=4.2.0
+    django52: django~=5.2.0
     sekizai: django-sekizai
     -r{toxinidir}/requirements-test.txt
 passenv =


### PR DESCRIPTION
# Description

Add support for Django 5.2 and python 3.12 and 3.13. Original pr was #215 , thanks to @kirmola .

## References

Fix #216 

# Checklist

* [x] I have read the [contribution guide](https://django-meta.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
