### PR TITLE
Add Django 6 and Python 3.14 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.13.x, 3.12.x, 3.11.x, 3.10.x, 3.9]
-        django: [52, 42]
+        python-version: [3.14.x, 3.13.x, 3.12.x, 3.11.x, 3.10.x, 3.9]
+        django: [60, 52, 42]
         sekizai: [sekizai,nosekizai]
         exclude:
+        - django: 60
+          python-version: 3.9
+        - django: 60
+          python-version: 3.10.x
+        - django: 60
+          python-version: 3.11.x
         - django: 52
           python-version: 3.9
         - django: 42
           python-version: 3.13.x
+        - django: 42
+          python-version: 3.14.x
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -28,14 +28,14 @@ Supported versions
 Django
 ******
 
-4.2 to 5.2 (newer versions might work but are not tested yet)
+4.2 to 6.0 (newer versions might work but are not tested yet)
 
 
 ******
 Python
 ******
 
-Python 3.9 to 3.13
+Python 3.9 to 3.14
 
 *******************
 Supported Meta Tags

--- a/changes/267.feature
+++ b/changes/267.feature
@@ -1,0 +1,1 @@
+Add python 3.14 and Django 6 compatibility

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
 	Framework :: Django
 	Framework :: Django :: 4.2
     Framework :: Django :: 5.2
+    Framework :: Django :: 6.0
 	Environment :: Web Environment
 	Intended Audience :: Developers
 	License :: OSI Approved :: BSD License
@@ -27,6 +28,7 @@ classifiers =
 	Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 include_package_data = True
@@ -43,7 +45,7 @@ meta = *.html *.png *.gif *js *jpg *jpeg *svg *py *mo *po
 
 [options.extras_require]
 docs =
-	django<6.0
+	django<7.0
 	sphinx-rtd-theme
 
 [sdist]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ envlist =
     ruff
     pypi-description
     towncrier
-    py{313,312,311,310}-django52-{sekizai,nosekizai}
+    py{314,313,312}-django60-{sekizai,nosekizai}
+    py{314,313,312,311,310}-django52-{sekizai,nosekizai}
     py{312,311,310}-django42-{sekizai,nosekizai}
 minversion = 3.23
 
@@ -17,6 +18,7 @@ commands = {env:COMMAND:python} cms_helper.py meta test {posargs}
 deps =
     django42: django~=4.2.0
     django52: django~=5.2.0
+    django60: django~=6.0.0
     sekizai: django-sekizai
     -r{toxinidir}/requirements-test.txt
 passenv =


### PR DESCRIPTION
# Description

Describe:

* Add Django 6 and Python 3.14 compatibility

## References

Fix #267 

# Checklist

* [x] I have read the [contribution guide](https://django-meta.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
