### PR TITLE
fix: prevent duplicate og:type when set via extra_custom_props

### DIFF
--- a/meta/templates/meta/meta.html
+++ b/meta/templates/meta/meta.html
@@ -25,8 +25,8 @@
           {% if meta.image_width %}{% og_prop 'image:width' meta.image_width %}{% endif %}
           {% if meta.image_height %}{% og_prop 'image:height' meta.image_height %}{% endif %}
         {% endif %}
-        {% if meta.og_type %}{% og_prop 'type' meta.og_type %}
-        {% elif meta.object_type %}{% og_prop 'type' meta.object_type %}{% endif %}
+        {% if not meta.has_og_type_in_custom_props %}{% if meta.og_type %}{% og_prop 'type' meta.og_type %}
+        {% elif meta.object_type %}{% og_prop 'type' meta.object_type %}{% endif %}{% endif %}
         {% if meta.site_name %}{% og_prop 'site_name' meta.site_name %}{% endif %}
         {% if meta.og_author_url %}{% generic_prop 'article' 'author' meta.og_author_url %}
         {% elif meta.og_author %}{% generic_prop 'article' 'author' meta.og_author %}{% endif %}

--- a/meta/views.py
+++ b/meta/views.py
@@ -269,6 +269,15 @@ class Meta(FullUrlMixin):
     def schema(self, schema):
         self._schema = schema
 
+    def has_og_type_in_custom_props(self):
+        """Return True if og:type is already defined in extra_custom_props."""
+        if not self.extra_custom_props:
+            return False
+        for prop in self.extra_custom_props:
+            if len(prop) >= 3 and prop[0] == "property" and prop[1] == "og:type":
+                return True
+        return False
+
     def as_json_ld(self):
         """
         Convert the schema to json-ld


### PR DESCRIPTION
Fixes #264

When `extra_custom_props` already contains an `og:type` property, the template was still rendering the `og_type`/`object_type` field separately, which produced a duplicate `<meta property="og:type">` tag. This breaks Open Graph validators that expect exactly one `og:type`.

**Changes:**
- Added `has_og_type_in_custom_props()` method to `Meta` class in `views.py` that checks whether `og:type` is already defined in `extra_custom_props`
- Updated `meta.html` template to skip the standard `og:type` output when that method returns `True`, letting the custom props version take precedence

The existing behavior is unchanged for anyone who doesn't set `og:type` via `extra_custom_props`.