### PR TITLE
fix: pin ruff version to 0.15.22

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.16.0'
+    rev: 'v0.15.22'
     hooks:
       - id: ruff
   - repo: https://github.com/econchick/interrogate
@@ -54,5 +54,4 @@ repos:
         always_run: true
 
 ci:
-  skip:
-    - towncrier
+  skip: [towncrier,ruff]

--- a/changes/291.bugfix
+++ b/changes/291.bugfix
@@ -1,0 +1,1 @@
+Pin ruff version to 0.15.22

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
     {envpython} -m ruff check meta tests
 deps =
     interrogate
-    ruff
+    ruff~=0.15.22
 skip_install = true
 
 [testenv:isort]


### PR DESCRIPTION
# Description

Pin ruff version to 0.15.22

## References

Fix #291 

# Checklist

* [x] I have read the [contribution guide](https://django-meta.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
